### PR TITLE
Allow directories in the `data-path` field

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,9 @@ and the current implementation is not flexible enough to be used with ROS.
 Instead, this extension consults a custom section in your `pyproject.toml`,
 called `tool.colcon-poetry-ros.data-files`.
 
-The format is intended to be identical to the `data_files` field used by
-[setuptools][setuptools-data-files].
+The format is intended to be mostly identical to the `data_files` field used
+by [setuptools][setuptools-data-files]. The main differences are that copying
+entire directories is supported, and globbing is not yet implemented.
 
 All ROS projects must have, at minimum, these entries in the
 `tool.colcon-poetry-ros.data-files` section (with `{package_name}` replaced

--- a/colcon_poetry_ros/task/poetry/build.py
+++ b/colcon_poetry_ros/task/poetry/build.py
@@ -198,7 +198,10 @@ class PoetryBuildTask(TaskExtensionPoint):
 
             for source in sources:
                 source_path = pkg.path / Path(source)
-                shutil.copy2(str(source_path), str(dest_path))
+                if source_path.is_dir():
+                    shutil.copytree(str(source_path), str(dest_path))
+                else:
+                    shutil.copy2(str(source_path), str(dest_path))
 
                 resulting_file = dest_path / source_path.name
                 if resulting_file == package_index_path:

--- a/colcon_poetry_ros/task/poetry/build.py
+++ b/colcon_poetry_ros/task/poetry/build.py
@@ -199,7 +199,7 @@ class PoetryBuildTask(TaskExtensionPoint):
             for source in sources:
                 source_path = pkg.path / Path(source)
                 if source_path.is_dir():
-                    shutil.copytree(str(source_path), str(dest_path))
+                    shutil.copytree(str(source_path), str(dest_path / source_path.name))
                 else:
                     shutil.copy2(str(source_path), str(dest_path))
 


### PR DESCRIPTION
This allows for entire directories can be copied using the `data-path` field in users' `pyproject.toml` files.