### PR TITLE
Source `poetry export` results from a temporary file

### DIFF
--- a/colcon_poetry_ros/package.py
+++ b/colcon_poetry_ros/package.py
@@ -82,7 +82,7 @@ class PoetryROSPackage:
         """
         # Create a temporary file for `poetry export` to write its output to. We can't
         # just capture stdout because Poetry 1.2 uses stdout for logging, too.
-        with NamedTemporaryFile() as requirements_file:
+        with NamedTemporaryFile("r") as requirements_file:
             command = [
                 "poetry",
                 "export",

--- a/colcon_poetry_ros/package.py
+++ b/colcon_poetry_ros/package.py
@@ -80,20 +80,20 @@ class PoetryROSPackage:
         :param extras: Names of extras whose dependencies should be included
         :return: The requirements.txt text
         """
+        command = [
+            "poetry",
+            "export",
+            "--format",
+            "requirements.txt",
+        ]
+
+        for extra in extras:
+            command += ["--extras", extra]
+
         # Create a temporary file for `poetry export` to write its output to. We can't
         # just capture stdout because Poetry 1.2 uses stdout for logging, too.
         with NamedTemporaryFile("r") as requirements_file:
-            command = [
-                "poetry",
-                "export",
-                "--format",
-                "requirements.txt",
-                "--output",
-                requirements_file.name,
-            ]
-
-            for extra in extras:
-                command += ["--extras", extra]
+            command += ["--output", requirements_file.name]
 
             try:
                 subprocess.run(


### PR DESCRIPTION
As of Poetry 1.2.0, diagnostics are printed to stdout when running `poetry export`. This breaks our existing code which expects dependencies in `requirements.txt` format to be written there. This change avoids that issue by instructing `export` to write its results to a temporary file that we then read.

Fixes #25 