### PR TITLE
Add an option to install dependencies using Poetry Bundle plugin

### DIFF
--- a/colcon_poetry_ros/dependencies/install.py
+++ b/colcon_poetry_ros/dependencies/install.py
@@ -76,8 +76,9 @@ def _install_dependencies_via_poetry_bundle(
         install_base /= project.name
 
     subprocess.run(
-        ["poetry", "bundle", "venv", str(install_base)],
-        check=True
+        ["poetry", "bundle", "venv", str(install_base.absolute())],
+        check=True,
+        cwd=project.path
     )
 
 

--- a/colcon_poetry_ros/dependencies/install.py
+++ b/colcon_poetry_ros/dependencies/install.py
@@ -63,7 +63,12 @@ def _install_dependencies_via_poetry_bundle(
     project: PoetryROSPackage, install_base: Path, merge_install: bool
 ) -> None:
     try:
-        subprocess.run(["poetry", "bundle", "venv", "--help"], check=True)
+        subprocess.run(
+            ["poetry", "bundle", "venv", "--help"],
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
     except subprocess.CalledProcessError as ex:
         logging.error(
             "The Poetry bundle plugin does not appear to be installed! See the "

--- a/colcon_poetry_ros/dependencies/install.py
+++ b/colcon_poetry_ros/dependencies/install.py
@@ -66,8 +66,9 @@ def _install_dependencies_via_poetry_bundle(
         subprocess.run(["poetry", "bundle", "venv", "--help"], check=True)
     except subprocess.CalledProcessError as ex:
         logging.error(
-            f"The Poetry bundle plugin does not appear to be installed! Original "
-            f"error: {ex}"
+            "The Poetry bundle plugin does not appear to be installed! See the "
+            "project page for installation instructions: "
+            "https://github.com/python-poetry/poetry-plugin-bundle"
         )
         sys.exit(1)
 
@@ -75,7 +76,7 @@ def _install_dependencies_via_poetry_bundle(
         install_base /= project.name
 
     subprocess.run(
-        ["poetry", "bundle", "venv", install_base],
+        ["poetry", "bundle", "venv", str(install_base)],
         check=True
     )
 

--- a/colcon_poetry_ros/dependencies/install.py
+++ b/colcon_poetry_ros/dependencies/install.py
@@ -18,41 +18,17 @@ def main():
 
     for project in _discover_packages(args.base_paths):
         logging.info(f"Installing dependencies for {project.path.name}...")
-
-        with NamedTemporaryFile("w") as requirements_file:
-            requirements_data = project.get_requirements_txt([])
-            requirements_file.write(requirements_data)
-            requirements_file.flush()
-
-            install_base = args.install_base
-            if not args.merge_install:
-                install_base /= project.name
-
-            subprocess.run(
-                [
-                    "python3",
-                    "-m",
-                    "pip",
-                    "install",
-                    # I don't understand why, but providing this fixes:
-                    # https://github.com/pypa/pip/issues/9644
-                    # Despite what the name would imply, dependencies are still
-                    # installed
-                    "--no-deps",
-                    # Forces installation even if the package is installed at the
-                    # system level
-                    "--ignore-installed",
-                    # Turns off Pip's check to ensure installed binaries are in the
-                    # PATH. ROS workspaces take care of setting the PATH, but Pip
-                    # doesn't know that.
-                    "--no-warn-script-location",
-                    "--requirement",
-                    requirements_file.name,
-                    "--prefix",
-                    install_base,
-                ],
-                check=True,
+        if args.method == "pip":
+            _install_dependencies_via_pip(
+                project, args.install_base, args.merge_install
             )
+        elif args.method == "bundle":
+            _install_dependencies_via_poetry_bundle(
+                project, args.install_base, args.merge_install
+            )
+        else:
+            logging.error(f"Invalid method argument: '{args.method}'")
+            sys.exit(1)
 
     logging.info("\nDependencies installed!")
 
@@ -83,10 +59,81 @@ def _discover_packages(base_paths: List[Path]) -> List[PoetryROSPackage]:
     return projects
 
 
+def _install_dependencies_via_poetry_bundle(
+    project: PoetryROSPackage, install_base: Path, merge_install: bool
+) -> None:
+    try:
+        subprocess.run(["poetry", "bundle", "venv", "--help"], check=True)
+    except subprocess.CalledProcessError as ex:
+        logging.error(
+            f"The Poetry bundle plugin does not appear to be installed! Original "
+            f"error: {ex}"
+        )
+        sys.exit(1)
+
+    if not merge_install:
+        install_base /= project.name
+
+    subprocess.run(
+        ["poetry", "bundle", "venv", install_base],
+        check=True
+    )
+
+
+def _install_dependencies_via_pip(
+    project: PoetryROSPackage, install_base: Path, merge_install: bool
+) -> None:
+    with NamedTemporaryFile("w") as requirements_file:
+        requirements_data = project.get_requirements_txt([])
+        requirements_file.write(requirements_data)
+        requirements_file.flush()
+
+        if not merge_install:
+            install_base /= project.name
+
+        subprocess.run(
+            [
+                "python3",
+                "-m",
+                "pip",
+                "install",
+                # I don't understand why, but providing this fixes:
+                # https://github.com/pypa/pip/issues/9644
+                # Despite what the name would imply, dependencies are still
+                # installed
+                "--no-deps",
+                # Forces installation even if the package is installed at the
+                # system level
+                "--ignore-installed",
+                # Turns off Pip's check to ensure installed binaries are in the
+                # PATH. ROS workspaces take care of setting the PATH, but Pip
+                # doesn't know that.
+                "--no-warn-script-location",
+                "--requirement",
+                requirements_file.name,
+                "--prefix",
+                install_base,
+            ],
+            check=True,
+        )
+
+
 def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Searches for ROS Poetry packages and installs their dependencies "
         "to a configurable install base"
+    )
+
+    parser.add_argument(
+        "--method",
+        type=str,
+        default="pip",
+        help="The method to use when installing dependencies. The 'pip' option exports "
+        "Poetry dependencies to a requirements.txt and installs them using the `pip` "
+        "command. This is the default option. The 'bundle' option uses the Poetry "
+        "Bundle plugin to install dependencies. This is the preferred option, but "
+        "using it requires Poetry 1.2.0 or higher and the Bundle plugin to be "
+        "installed."
     )
 
     parser.add_argument(


### PR DESCRIPTION
This PR adds a new flag to the dependency installation script, `--method`, which controls the way in which dependencies are installed. By default, the script will still use the old Pip+`poetry export` behavior. If `--method` is set to `bundle`, the Poetry Bundle plugin will be used. Theoretically this should be the preferred option, as it allows Poetry to do all dependency resolution work at install time instead of involving Pip. However, it requires the newly released Poetry 1.2.0 and the Bundle plugin to be installed. This may become the default option in the future if it doesn't cause issues for anyone.

Dependency detection is now done using `poetry show` instead of by parsing the `requirements.txt` provided by `poetry export`. This is a simpler option, and makes it possible to completely remove uses of `poetry export` in the future.

Fixes #27