### PR TITLE
Augments colcon pkg with dependencies from pyproject file.

### DIFF
--- a/colcon_poetry_ros/package_augmentation/poetry.py
+++ b/colcon_poetry_ros/package_augmentation/poetry.py
@@ -14,7 +14,7 @@ from colcon_poetry_ros.package_identification.poetry import PoetryPackage
 class PoetryPackageAugmentation(PackageAugmentationExtensionPoint):
     """Augment Python packages that use Poetry by referencing the pyproject.toml file"""
 
-    _PACKAGE_SECTION = "colcon-package"
+    _PACKAGE_SECTION = "tool.colcon-poetry-ros.dependencies"
     _DEPEND_LIST = "depend"
     _BUILD_DEPEND_LIST = "build_depend"
     _EXEC_DEPEND_LIST = "exec_depend"


### PR DESCRIPTION
Related to #37 

### Summary

This PR introduces the ability to indicate the colcon/ros dependencies of the project via the `pyproject.toml` file.
Otherwise, dependencies for the package aren't loaded up, and the ordering when building isn't respected

### Use

Add to `pyproject.toml` the following section:

```toml
[colcon-package]
depend = ["another_pkg_1"]   # This will add to both `build_depend` and `exec_depend` following `package.xml` standards
build_depend = ["another_pkg_2"]
exec_depend = ["another_pkg_3"]
test_depend = ["another_pkg_4"]
```
